### PR TITLE
[#1666] RFC: add support for optional custom error message for Configuration Validation Errors

### DIFF
--- a/Definition/BaseNode.php
+++ b/Definition/BaseNode.php
@@ -105,6 +105,26 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Sets an error message.
+     *
+     * @param string $errorMessage
+     */
+    public function setErrorMessage($errorMessage)
+    {
+        $this->setAttribute('errorMessage', $errorMessage);
+    }
+
+    /**
+     * Returns error message.
+     *
+     * @return string The error message
+     */
+    public function getErrorMessage()
+    {
+        return $this->getAttribute('errorMessage');
+    }
+
+    /**
      * Sets the example configuration for this node.
      *
      * @param string|array $example

--- a/Definition/Builder/NodeDefinition.php
+++ b/Definition/Builder/NodeDefinition.php
@@ -77,6 +77,17 @@ abstract class NodeDefinition implements NodeParentInterface
     }
 
     /**
+     * Sets error message.
+     *
+     * @param string $errorMessage The error message text
+     * @return NodeDefinition
+     */
+    public function errorMessage($errorMessage)
+    {
+        return $this->attribute('errorMessage', $errorMessage);
+    }
+
+    /**
      * Sets example configuration.
      *
      * @param string|array $example

--- a/Definition/ScalarNode.php
+++ b/Definition/ScalarNode.php
@@ -34,11 +34,17 @@ class ScalarNode extends VariableNode
     protected function validateType($value)
     {
         if (!is_scalar($value) && null !== $value) {
-            $ex = new InvalidTypeException(sprintf(
+            $errorMessage = $this->getErrorMessage();
+            $finalMessage = sprintf(
                 'Invalid type for path "%s". Expected scalar, but got %s.',
                 $this->getPath(),
                 gettype($value)
-            ));
+            );
+            if ($errorMessage != null) {
+                $finalMessage .= sprintf("\nError message: %s.", $errorMessage);
+            }
+
+            $ex = new InvalidTypeException($finalMessage);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/Definition/VariableNode.php
+++ b/Definition/VariableNode.php
@@ -83,11 +83,17 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     protected function finalizeValue($value)
     {
         if (!$this->allowEmptyValue && empty($value)) {
-            $ex = new InvalidConfigurationException(sprintf(
+            $errorMessage = $this->getErrorMessage();
+            $finalMessage = sprintf(
                 'The path "%s" cannot contain an empty value, but got %s.',
                 $this->getPath(),
                 json_encode($value)
-            ));
+            );
+            if ($errorMessage != null) {
+                $finalMessage .= sprintf("\nError message: %s.", $errorMessage);
+            }
+
+            $ex = new InvalidConfigurationException($finalMessage);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/Tests/Definition/Builder/TreeBuilderTest.php
@@ -124,4 +124,21 @@ class TreeBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($tree->getExample()));
         $this->assertEquals('example', $children['child']->getExample());
     }
+
+    public function testDefinitionErrorMessageGetsTransferedToNode()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('test')->errorMessage('You are missing the root node')
+            ->children()
+            ->node('child', 'variable')->errorMessage('child error message')->defaultValue('default')
+            ->end()
+            ->end();
+
+        $tree = $builder->buildTree();
+        $children = $tree->getChildren();
+
+        $this->assertEquals('You are missing the root node', $tree->getErrorMessage());
+        $this->assertEquals('child error message', $children['child']->getErrorMessage());
+    }
 }

--- a/Tests/Definition/ScalarNodeTest.php
+++ b/Tests/Definition/ScalarNodeTest.php
@@ -57,4 +57,42 @@ class ScalarNodeTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass()),
         );
     }
+
+    public function testNormalizeThrowsExceptionWithoutErrorMessage()
+    {
+        $value = array(array('foo' => 'bar'));
+        $node = new ScalarNode('test');
+
+        $expectedMessage = sprintf(
+            'Invalid type for path "%s". Expected scalar, but got %s.',
+            $node->getPath(),
+            gettype($value)
+        );
+
+        $this->setExpectedException(
+            'Symfony\Component\Config\Definition\Exception\InvalidTypeException', $expectedMessage
+        );
+
+        $node->normalize($value);
+    }
+
+    public function testNormalizeThrowsExceptionWithErrorMessage()
+    {
+        $value = array(array('foo' => 'bar'));
+        $node = new ScalarNode('test');
+        $node->setErrorMessage('This is a custom error message');
+
+        $expectedMessage = sprintf(
+            'Invalid type for path "%s". Expected scalar, but got %s.'.
+                "\nError message: ".$node->getErrorMessage(),
+            $node->getPath(),
+            gettype($value)
+        );
+
+        $this->setExpectedException(
+            'Symfony\Component\Config\Definition\Exception\InvalidTypeException', $expectedMessage
+        );
+
+        $node->normalize($value);
+    }
 }


### PR DESCRIPTION
RFC:

Basically this is the start, but i wanted to ask which one of these options is better:
1. extend/override the base Exception class to include the custom error message
   this requires a modification of the throw specific expection passing Exception($this) meaning it is getting
   the current node or the node from which the exception is being thrown
2. propagate the changes in every class that throws exception similar than this PR
   this would require changes in every particular class

Please vote whether 1 or 2 is more fit

Thanks to all symfony2 community :D
