### PR TITLE
Fix deprecated message

### DIFF
--- a/Definition/BaseNode.php
+++ b/Definition/BaseNode.php
@@ -499,7 +499,7 @@ abstract class BaseNode implements NodeInterface
                 return self::$placeholders[$value];
             }
 
-            if (0 === strpos($value, self::$placeholderUniquePrefix)) {
+            if (self::$placeholderUniquePrefix === null || 0 === strpos($value, self::$placeholderUniquePrefix)) {
                 return array();
             }
         }


### PR DESCRIPTION
Got a message from a nightly build that has its reason on this code-location because $placeholderUniquePrefix could not be initialized.

Deprecated message "Non-string needles will be interpreted as strings in
 the future. Use an explicit chr() call to preserve the current
 behavior" will not occur because of a non-set $placeholderUniquePrefix
 anymore