### PR TITLE
Changed @return type

### DIFF
--- a/Definition/Builder/ExprBuilder.php
+++ b/Definition/Builder/ExprBuilder.php
@@ -91,7 +91,7 @@ class ExprBuilder
     /**
      * Tests if the value is empty.
      *
-     * @return ExprBuilder
+     * @return $this
      */
     public function ifEmpty()
     {


### PR DESCRIPTION
phpstan probably moans otherwise: Call to an undefined method Symfony\Component\Config\Definition\Builder\NodeParentInterface::scalarNode().
```php
->ifTrue(function ($v) {return empty($v);})
```
does not cause any errors.